### PR TITLE
Add Python implementation

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,12 @@
+from speak import speak
+from weather import fetch_weather
+
+
+def main() -> None:
+    text = fetch_weather()
+    print(text)
+    speak(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/speak.py
+++ b/speak.py
@@ -1,0 +1,39 @@
+import subprocess
+import shlex
+import shutil
+
+
+def command_exists(cmd: str) -> bool:
+    """Return True if the given command exists on PATH."""
+    return shutil.which(cmd) is not None
+
+
+def speak_with_open_jtalk(text: str) -> None:
+    """Speak text using open_jtalk and aplay."""
+    safe_text = shlex.quote(text)
+    cmd = [
+        f"echo {safe_text}",
+        "|",
+        "open_jtalk",
+        "-x /var/lib/mecab/dic/open-jtalk/naist-jdic",
+        "-m /usr/share/hts-voice/nitech-jp-atr503-m001/nitech_jp_atr503_m001.htsvoice",
+        "-ow /dev/stdout",
+        "|",
+        "aplay --quiet",
+    ]
+    subprocess.run(" ".join(cmd), shell=True, check=False)
+
+
+def speak_with_say(text: str) -> None:
+    """Speak text using the 'say' command (macOS)."""
+    subprocess.run(["say", text], check=False)
+
+
+def speak(text: str) -> None:
+    """Speak the provided text using available system commands."""
+    if command_exists("say"):
+        speak_with_say(text)
+    elif command_exists("open_jtalk") and command_exists("aplay"):
+        speak_with_open_jtalk(text)
+    else:
+        print("`say`または`open_jtalk aplay`が見つかりませんでした。")

--- a/weather.py
+++ b/weather.py
@@ -1,0 +1,22 @@
+import json
+import urllib.request
+
+AREA_CODE = "270000"
+AREA_NAME = "大阪"
+INDEX_TODAY = 0
+
+
+def fetch_weather() -> str:
+    """Fetch today's weather text from the JMA forecast API."""
+    url = f"https://www.jma.go.jp/bosai/forecast/data/forecast/{AREA_CODE}.json"
+    try:
+        with urllib.request.urlopen(url, timeout=5) as response:
+            data = json.load(response)
+        today = (
+            data[0]["timeSeries"][0]["areas"][0]["weathers"][INDEX_TODAY]
+            .replace("\u3000", " ")
+        )
+        return f"{AREA_NAME}の今日の天気は「{today}」です。"
+    except Exception as e:
+        print("天気取得エラー:", getattr(e, "message", str(e)))
+        return "天気情報の取得に失敗しました"


### PR DESCRIPTION
## Summary
- reimplement weather fetcher and speech in Python
- keep existing JavaScript files

## Testing
- `npm test` *(fails: no test specified)*
- `python3 main.py`
- `python3 -m py_compile main.py speak.py weather.py`
- `python3 -m unittest discover`


------
https://chatgpt.com/codex/tasks/task_e_684d51b6dad4832183fc893951706471