### PR TITLE
Fix param naming in format_time_to_digit_reading

### DIFF
--- a/headless_gamepad_speaker/tasks/time.py
+++ b/headless_gamepad_speaker/tasks/time.py
@@ -13,8 +13,8 @@ DIGIT_MAP = {
     '9': 'キュウ',
 }
 
-def format_time_to_digit_reading(time:str) -> str:
-    return ''.join("「"+DIGIT_MAP[d]+"」" for d in time)
+def format_time_to_digit_reading(time_str: str) -> str:
+    return ''.join("「"+DIGIT_MAP[d]+"」" for d in time_str)
 
 # open_jtalkが数字を読むのが苦手なので一桁ずつ読む
 def fetch_time() -> str:


### PR DESCRIPTION
## Summary
- rename `time` parameter in `format_time_to_digit_reading` to `time_str`
- update internal references

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851ab35768483219506ad4689763ad2