### PR TITLE
Allow custom speech function for App

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@
 ## カスタマイズ
 
 天気予報は気象庁から取得します。ボタンに割り当てる処理を変更したい場合は、`main.py` を編集するか、次のようなスクリプトを作成してください。
+`App` の ``speak_func`` 引数を使うと、音声出力処理も自由に差し替えられます。
 
 ```python
 from headless_gamepad_speaker import App
@@ -74,6 +75,21 @@ app.register_button(
     ),
 )
 app.run()
+```
+
+### 任意の音声合成の利用
+
+`App` は `speak_func` 引数で音声出力用の関数を差し替えられます。既定では
+`headless_gamepad_speaker.speak` を使用しますが、以下のように独自の関数を
+指定することもできます。
+
+```python
+from headless_gamepad_speaker import App
+
+def debug_speak(text: str) -> None:
+    print(f"VOICE: {text}")
+
+app = App(speak_func=debug_speak)
 ```
 
 ## ライセンス

--- a/headless_gamepad_speaker/__init__.py
+++ b/headless_gamepad_speaker/__init__.py
@@ -1,5 +1,6 @@
 """Headless Gamepad Speaker library."""
 from .app import App
+from .speak import speak
 from .tasks import (
     fetch_time,
     fetch_weather_today,
@@ -8,6 +9,7 @@ from .tasks import (
 )
 __all__ = [
     "App",
+    "speak",
     "fetch_time",
     "fetch_weather_today",
     "fetch_weather_tomorrow",

--- a/headless_gamepad_speaker/app.py
+++ b/headless_gamepad_speaker/app.py
@@ -14,8 +14,10 @@ except Exception:
 class App:
     """Register button handlers and dispatch events via pygame."""
 
-    def __init__(self) -> None:
+    def __init__(self, speak_func: Callable[[str], None] = speak) -> None:
+        """Initialize with optional custom speak function."""
         self._handlers: Dict[int, Callable[[], str]] = {}
+        self._speak = speak_func
 
     def register_button(self, num: int, func: Callable[[], str]) -> None:
         """Register ``func`` as the handler for button ``num``."""
@@ -40,7 +42,7 @@ class App:
         if pygame is None:
             message = "ゲームパッド操作にはpygameライブラリが必要です。"
             print(message)
-            speak(message)
+            self._speak(message)
             return
 
         pygame.init()
@@ -62,7 +64,7 @@ class App:
                                 text = handler()
                                 if text:
                                     print(text)
-                                    speak(text)
+                                    self._speak(text)
                         elif (
                             hasattr(pygame, "JOYDEVICEREMOVED")
                             and event.type == pygame.JOYDEVICEREMOVED


### PR DESCRIPTION
## Summary
- support injecting a custom speech function into `App`
- expose `speak` in package exports
- document how to use the new `speak_func` argument

## Testing
- `python -m pip install -r requirements.txt`
- `python -m compileall -q headless_gamepad_speaker main.py`


------
https://chatgpt.com/codex/tasks/task_e_6851ac13705483219fe966e66090d8ef