### PR TITLE
Allow env overrides for open_jtalk paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,14 @@ def debug_speak(text: str) -> None:
 app = App(speak_func=debug_speak)
 ```
 
+### open_jtalkの設定
+
+`open_jtalk` を使用する際、辞書ディレクトリと音声ファイルのパスは
+`OPEN_JTALK_DICT` と `OPEN_JTALK_VOICE` 環境変数で変更できます。あるいは
+`speak_with_open_jtalk()` に ``dic_path`` と ``voice_path`` 引数を渡して指定
+することも可能です。
+
+
 ## ライセンス
 
 このプロジェクトは MIT ライセンスのもとで配布しています。

--- a/headless_gamepad_speaker/speak.py
+++ b/headless_gamepad_speaker/speak.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import shutil
 
@@ -7,14 +8,27 @@ def command_exists(cmd: str) -> bool:
     return shutil.which(cmd) is not None
 
 
-def speak_with_open_jtalk(text: str) -> None:
+def speak_with_open_jtalk(
+    text: str,
+    *,
+    dic_path: str | None = None,
+    voice_path: str | None = None,
+) -> None:
     """Speak text using open_jtalk and aplay without invoking a shell."""
+    dic = dic_path or os.getenv(
+        "OPEN_JTALK_DICT",
+        "/var/lib/mecab/dic/open-jtalk/naist-jdic",
+    )
+    voice = voice_path or os.getenv(
+        "OPEN_JTALK_VOICE",
+        "/usr/share/hts-voice/nitech-jp-atr503-m001/nitech_jp_atr503_m001.htsvoice",
+    )
     jtalk_cmd = [
         "open_jtalk",
         "-x",
-        "/var/lib/mecab/dic/open-jtalk/naist-jdic",
+        dic,
         "-m",
-        "/usr/share/hts-voice/nitech-jp-atr503-m001/nitech_jp_atr503_m001.htsvoice",
+        voice,
         "-ow",
         "/dev/stdout",
     ]


### PR DESCRIPTION
## Summary
- override open_jtalk dictionary and voice paths with environment variables
- document OPEN_JTALK_DICT and OPEN_JTALK_VOICE settings in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6851b140362c8321a12dab0f13d75f8f